### PR TITLE
Can process more zip patterns, added tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ varsub -w d:\Projects\artifacts -j **/appsettings.json
 
 **--variables, -v**: Variables. (var1=value1 var2=value2)
 
-This tool processes all ZIP files that match the `--zipFilesOrDirectories` pattern in working directory. Processes all files that match the `--jsonTargetFiles` pattern. By default, it takes variables from environment variables. It tries to find the corresponding property in the JSON object for these variables. If  finds, will replace it.
+This tool processes all ZIP files that match the `--zipFilesOrDirectories` pattern in working directory. Multiple glob patterns are allowed (`-f *pattern.zip -f **/anotherPattern.zip ...`). Processes all files that match the `--jsonTargetFiles` pattern. By default, it takes variables from environment variables. It tries to find the corresponding property in the JSON object for these variables. If a match is found, it will replace it.
 
-The `--variables` parameter can be used mainly for testing purposes, with which it is possible to define variables and their values (`--variables var1=value1 var2=value2 ...`).
+The `--variables` parameter can be used mainly for testing purposes, with which it is possible to define variables and their values (`--variables var1=value1 --variables var2=value2 ...`).
 
 > ⚠ It is not possible to add a new property to a JSON object or a new record to a JSON field using this tool. It only allows the replacement of existing properties.

--- a/src/Kros.VariableSubstitution/Program.cs
+++ b/src/Kros.VariableSubstitution/Program.cs
@@ -10,11 +10,11 @@ using System.Linq;
 
 namespace Kros.VariableSubstitution
 {
-    class Program
+    internal class Program
     {
         private static ILoggerFactory _loggerFactory;
         private static ILogger _logger;
-        static int Main(string[] args)
+        public static int Main(string[] args)
         {
             _loggerFactory = CreateLoggerFactory();
             _logger = _loggerFactory.CreateLogger(string.Empty);

--- a/tests/Kros.VariableSubstitution.Tests/CommandLineParserShould.cs
+++ b/tests/Kros.VariableSubstitution.Tests/CommandLineParserShould.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.IO;
+using Xunit;
+namespace Kros.VariableSubstitution.Tests
+{
+    public class CommandLineParserShould
+    {
+        [Fact]
+        public void MissingParametersOutput()
+        {
+            var stringWriter = new StringWriter();
+            Console.SetOut(stringWriter);
+            Program.Main(new string[] { });
+            var output = stringWriter.ToString();
+            Assert.Contains("Run variable substitution in Json files.", output);
+        }
+
+        [Fact]
+        public void WrongVariableFormatOutput()
+        {
+            var stringWriter = new StringWriter();
+            Console.SetOut(stringWriter);
+            Program.Main(new string[] { "-w", "placeholder", "-v", "incorrectVariable" });
+            var output = stringWriter.ToString();
+            Assert.Contains("Error while parsing", output);
+        }
+    }
+}

--- a/tests/Kros.VariableSubstitution.Tests/CommandLineParserShould.cs
+++ b/tests/Kros.VariableSubstitution.Tests/CommandLineParserShould.cs
@@ -1,28 +1,23 @@
-﻿using System;
-using System.IO;
+﻿using FluentAssertions;
+using System.Collections.Generic;
 using Xunit;
+
 namespace Kros.VariableSubstitution.Tests
 {
     public class CommandLineParserShould
     {
-        [Fact]
-        public void MissingParametersOutput()
+        [Theory]
+        [MemberData(nameof(GetArgs))]
+        public void ConsoleOutput(string[] args, int expectedReturn)
         {
-            var stringWriter = new StringWriter();
-            Console.SetOut(stringWriter);
-            Program.Main(new string[] { });
-            var output = stringWriter.ToString();
-            Assert.Contains("Run variable substitution in Json files.", output);
+            var actual = Program.Main(args);
+            actual.Should().Be(expectedReturn);
         }
 
-        [Fact]
-        public void WrongVariableFormatOutput()
+        public static IEnumerable<object[]> GetArgs()
         {
-            var stringWriter = new StringWriter();
-            Console.SetOut(stringWriter);
-            Program.Main(new string[] { "-w", "placeholder", "-v", "incorrectVariable" });
-            var output = stringWriter.ToString();
-            Assert.Contains("Error while parsing", output);
+            yield return new object[] { new string[] { }, ExitCodes.MissingWorkingDirectory };
+            yield return new object[] { new string[] { "-w", "placeholder", "-v", "incorrectVariable" }, ExitCodes.WrongVariablesFormat };
         }
     }
 }

--- a/tests/Kros.VariableSubstitution.Tests/MainReturnShould.cs
+++ b/tests/Kros.VariableSubstitution.Tests/MainReturnShould.cs
@@ -7,14 +7,14 @@ namespace Kros.VariableSubstitution.Tests
     public class MainReturnShould
     {
         [Theory]
-        [MemberData(nameof(GetArgs))]
+        [MemberData(nameof(TestDifferentArgs_Data))]
         public void TestDifferentArgs(string[] args, int expectedReturn)
         {
             var actual = Program.Main(args);
             actual.Should().Be(expectedReturn);
         }
 
-        public static IEnumerable<object[]> GetArgs()
+        public static IEnumerable<object[]> TestDifferentArgs_Data()
         {
             yield return new object[] { new string[] { }, ExitCodes.MissingWorkingDirectory };
             yield return new object[] { new string[] { "-w", "placeholder", "-v", "incorrectVariable" }, ExitCodes.WrongVariablesFormat };

--- a/tests/Kros.VariableSubstitution.Tests/MainReturnShould.cs
+++ b/tests/Kros.VariableSubstitution.Tests/MainReturnShould.cs
@@ -4,11 +4,11 @@ using Xunit;
 
 namespace Kros.VariableSubstitution.Tests
 {
-    public class CommandLineParserShould
+    public class MainReturnShould
     {
         [Theory]
         [MemberData(nameof(GetArgs))]
-        public void ConsoleOutput(string[] args, int expectedReturn)
+        public void TestDifferentArgs(string[] args, int expectedReturn)
         {
             var actual = Program.Main(args);
             actual.Should().Be(expectedReturn);


### PR DESCRIPTION
Tool can now process multiple `zipFilesOrDirectories`  patterns in format `-f *firstPattern.zip -f **/anotherPattern.zip` and so on.